### PR TITLE
Move site description off of CRA's default text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="USB2SNES Automated Guessing Games (Alpha)"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
This syncs the site's description with what's in the app's
header. That way hovering over any links will render a more
useful description of the site rather than the generic
"created via CRA" text.

Ideally this should be DRY'd up a bit, but that'd require
ejecting which would add more complexity than desirable
for such a small tweak.

![image](https://user-images.githubusercontent.com/6256971/128616578-11ece4f1-cdac-49d1-9023-4b0b3b93d08d.png)
